### PR TITLE
Use Github Actions instead of deploying to gh-pages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches-ignore:
       - 'gh-pages'
+  workflow_dispatch:
 
 jobs:
   build:
@@ -28,36 +29,23 @@ jobs:
       - name: Run Eleventy build
         run: npm run-script build
 
-      - name: Archive build output
-        run: tar --dereference --hard-dereference --directory _site/ -cvf artifact.tar .
-
       - name: Upload build output
-        uses: actions/upload-artifact@v2
-        with:
-          name: gh-pages
-          path: artifact.tar
-          if-no-files-found: warn
+        uses: actions/upload-pages-artifact@v1
 
   deploy:
     name: Deploy
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     needs: build
     if: ${{ github.ref == 'refs/heads/master' && github.event_name == 'push' && github.actor != 'dependabot' }}
     runs-on: ubuntu-latest
 
     steps:
-      - name: Download build
-        uses: actions/download-artifact@v2
-        with:
-          name: gh-pages
-
-      - name: Extract build
-        run: |
-          mkdir _site
-          tar -xvf artifact.tar -C _site
-
-      - name: Deploy to Github pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          publish_dir: _site 
-          publish_branch: gh-pages
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@ This repository contains the [Eleventy](https://www.11ty.dev/) source code for
 the SimpleID web site, hosted on [GitHub Pages](http://pages.github.com/).  You
 can see a much prettier version at http://simpleid.org/.
 
-Currently, the web site is built using a Github Actions script and then pushed
-to the `gh-pages` branch, which is then picked up by Github and deployed.
-At a later stage, when Github finalises the `actions\deploy-pages` action,
-the web site will be deployed directly from this branch.
+Currently, the web site is built using a Github Actions script and then deployed
+using the `actions/deploy-pages` action.
 
 To report bugs, please lodge a ticket at https://github.com/simpleid/simpleid/issues


### PR DESCRIPTION
Save on deployment time and resources by deploying directly using Github Actions.

https://github.blog/2022-08-10-github-pages-now-uses-actions-by-default/